### PR TITLE
Capitalise title text (excludes title replacements)

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -185,6 +185,8 @@ Item {
         replacements = replacements.replace(/, | ,/g, ",");
 
         var appReplacements = replacements.split(";");
+        
+        title = title.charAt(0).toUpperCase() + title.substr(1);
 
         for (var iReplacement = 0; iReplacement < appReplacements.length; iReplacement++){
 


### PR DESCRIPTION
This reenables the capitalisation feature of the widget, but only has it apply to things which don't have their text replaced. More accurately, it capitalises the text, but has it replaced afterwards.